### PR TITLE
Add API1 Broken Object Level Authorization example

### DIFF
--- a/src/API1 2023 Broken Object Level Authorization/Api/Api.csproj
+++ b/src/API1 2023 Broken Object Level Authorization/Api/Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/API1 2023 Broken Object Level Authorization/Api/Controllers/UsersController.cs
+++ b/src/API1 2023 Broken Object Level Authorization/Api/Controllers/UsersController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private static readonly List<User> Users = new()
+    {
+        new User(1, "Alice", "alice@example.com", "https://via.placeholder.com/150"),
+        new User(2, "Bob", "bob@example.com", "https://via.placeholder.com/150")
+    };
+
+    [HttpGet("{id}")]
+    public ActionResult<User> Get(int id)
+    {
+        var user = Users.FirstOrDefault(u => u.Id == id);
+        if (user is null)
+        {
+            return NotFound();
+        }
+        return Ok(user);
+    }
+}
+
+public record User(int Id, string Name, string Email, string ImageUrl);

--- a/src/API1 2023 Broken Object Level Authorization/Api/Program.cs
+++ b/src/API1 2023 Broken Object Level Authorization/Api/Program.cs
@@ -1,0 +1,9 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/src/API1 2023 Broken Object Level Authorization/Client/App.razor
+++ b/src/API1 2023 Broken Object Level Authorization/Client/App.razor
@@ -1,0 +1,8 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound>
+        <p>Sidan kunde inte hittas.</p>
+    </NotFound>
+</Router>

--- a/src/API1 2023 Broken Object Level Authorization/Client/Client.csproj
+++ b/src/API1 2023 Broken Object Level Authorization/Client/Client.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/API1 2023 Broken Object Level Authorization/Client/Pages/Profile.razor
+++ b/src/API1 2023 Broken Object Level Authorization/Client/Pages/Profile.razor
@@ -1,0 +1,26 @@
+@page "/profile"
+@inject HttpClient Http
+
+<h3>Användarprofil</h3>
+
+@if (user is null)
+{
+    <p>Laddar...</p>
+}
+else
+{
+    <img src="@user.ImageUrl" alt="profil" />
+    <p>@user.Name</p>
+    <p>@user.Email</p>
+}
+
+@code {
+    private User? user;
+
+    protected override async Task OnInitializedAsync()
+    {
+        user = await Http.GetFromJsonAsync<User>("api/users/1");
+    }
+
+    public record User(int Id, string Name, string Email, string ImageUrl);
+}

--- a/src/API1 2023 Broken Object Level Authorization/Client/Pages/_Imports.razor
+++ b/src/API1 2023 Broken Object Level Authorization/Client/Pages/_Imports.razor
@@ -1,0 +1,4 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web

--- a/src/API1 2023 Broken Object Level Authorization/Client/Program.cs
+++ b/src/API1 2023 Broken Object Level Authorization/Client/Program.cs
@@ -1,0 +1,11 @@
+using Client;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:5001/") });
+
+await builder.Build().RunAsync();

--- a/src/API1 2023 Broken Object Level Authorization/Client/wwwroot/index.html
+++ b/src/API1 2023 Broken Object Level Authorization/Client/wwwroot/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Client</title>
+    <base href="/" />
+</head>
+<body>
+    <div id="app">Laddar...</div>
+
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/src/API1 2023 Broken Object Level Authorization/README.md
+++ b/src/API1 2023 Broken Object Level Authorization/README.md
@@ -1,0 +1,9 @@
+# API1:2023 Broken Object Level Authorization
+
+Denna sårbarhet uppstår när ett API inte kontrollerar att den autentiserade användaren har behörighet att läsa eller ändra det objekt som begärs.
+Angripare kan manipulera objektidentifierare (t.ex. användar-ID) i URL:er eller parametrar för att komma åt andra användares data.
+
+## Exempel
+
+Detta exempel innehåller ett API som returnerar användarprofil baserat på ett `id`. API:t verifierar inte att anroparen har rätt att hämta uppgifterna.
+Genom att ändra parametern kan en angripare få åtkomst till andra användares uppgifter.


### PR DESCRIPTION
## Summary
- document API1:2023 Broken Object Level Authorization
- add sample Web API returning user data by id without authorization
- add Blazor WASM profile page consuming the vulnerable API

## Testing
- `dotnet build 'src/API1 2023 Broken Object Level Authorization/Api/Api.csproj'` (fails: command not found)
- `dotnet build 'src/API1 2023 Broken Object Level Authorization/Client/Client.csproj'` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ac5f9b0f10832a989f0436152ab37b